### PR TITLE
Update explainer.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # clipboard-pickling
 An explainer and questionnaire for the Pickling proposal for the Clipboard API.
+
+## NOTE: This repo's contents have [moved](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/) to the [w3c/editing repository](https://github.com/w3c/editing) in [this PR](https://github.com/w3c/editing/pull/307). Content in this repo may no longer be up to date, but is being left here for linkability / posterity.

--- a/explainer.md
+++ b/explainer.md
@@ -1,5 +1,6 @@
 # Pickling for Async Clipboard API
 
+## NOTE: This explainer has now been [moved](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md#pickling-for-async-clipboard-api) to the [w3c/editing repository](https://github.com/w3c/editing)!
 
 ## Author:
 *   huangdarwin@chromium.org

--- a/explainer.md
+++ b/explainer.md
@@ -1,6 +1,6 @@
 # Pickling for Async Clipboard API
 
-## NOTE: This explainer has now been [moved](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md#pickling-for-async-clipboard-api) to the [w3c/editing repository](https://github.com/w3c/editing)!
+## NOTE: This explainer has now [moved](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md#pickling-for-async-clipboard-api) to the [w3c/editing repository](https://github.com/w3c/editing)!
 
 ## Author:
 *   huangdarwin@chromium.org


### PR DESCRIPTION
Per https://github.com/w3c/editing/pull/307 , the pickling explainer is now in the w3c editing repo. Updating this repo's documents to make this clear (especially in case this explainer version eventually becomes out of date)

I assume new edits may be made to the w3c/editing repo directly, without any edit to this repository, and that this repository may slowly become out of date. I'll keep this repo around for linkability (Chrome release docs mostly point to this for now), and posterity (in case the git commit history or similar might be useful), but otherwise I don't expect much activity here in the future